### PR TITLE
fix: scope JdbcMfaAccountMethodsRepository.findAll to the requesting user

### DIFF
--- a/auth-server/src/main/kotlin/com/vauthenticator/server/mfa/adapter/jdbc/JdbcMfaAccountMethodsRepository.kt
+++ b/auth-server/src/main/kotlin/com/vauthenticator/server/mfa/adapter/jdbc/JdbcMfaAccountMethodsRepository.kt
@@ -32,8 +32,11 @@ class JdbcMfaAccountMethodsRepository(
         ).firstOrNull()
 
     override fun findAll(userName: String): List<MfaAccountMethod> =
-        jdbcTemplate.query("SELECT * FROM MFA_ACCOUNT_METHODS")
-        { rs, _ -> mfaAccountMethodFrom(rs) }
+        jdbcTemplate.query(
+            "SELECT * FROM MFA_ACCOUNT_METHODS WHERE user_name=?",
+            { rs, _ -> mfaAccountMethodFrom(rs) },
+            userName
+        )
 
 
     override fun save(

--- a/auth-server/src/test/kotlin/com/vauthenticator/server/mfa/adapter/AbstractMfaAccountMethodsRepositoryTest.kt
+++ b/auth-server/src/test/kotlin/com/vauthenticator/server/mfa/adapter/AbstractMfaAccountMethodsRepositoryTest.kt
@@ -53,6 +53,21 @@ abstract class AbstractMfaAccountMethodsRepositoryTest {
     }
 
     @Test
+    fun `findAll does not leak other accounts' mfa methods`() {
+        val otherEmail = "other-$email"
+
+        uut.save(email, MfaMethod.EMAIL_MFA_METHOD, email, true)
+        uut.save(otherEmail, MfaMethod.EMAIL_MFA_METHOD, otherEmail, true)
+
+        val mfaAccountMethods = uut.findAll(email)
+
+        assertEquals(
+            listOf(MfaAccountMethod(email, mfaDeviceId, key, MfaMethod.EMAIL_MFA_METHOD, email, true)),
+            mfaAccountMethods
+        )
+    }
+
+    @Test
     fun `when try to get one specific enrolment association`() {
         every { keyRepository.createKeyFrom(masterKid, KeyType.SYMMETRIC, KeyPurpose.MFA) } returns Kid("")
 


### PR DESCRIPTION
## Summary
- `findAll` ran a bare `SELECT * FROM MFA_ACCOUNT_METHODS`, ignoring the `userName` argument. Under the `database` (JDBC/Postgres) profile this let `GET /api/mfa/enrollment` return every account's MFA devices once the caller had a default device set (the call site is gated by the correctly-scoped `getDefaultDevice`). Adds `WHERE user_name=?`, matching `findBy`/`setAsDefault`/`getDefaultDevice` in the same class.
- Adds a regression test to `AbstractMfaAccountMethodsRepositoryTest` (shared by both the JDBC and DynamoDB suites): saves MFA methods for two different accounts and asserts `findAll` returns only the caller's own.

## Test plan
- [x] `./mvnw -Dtest=JdbcMfaAccountMethodsRepositoryTest test` — 8/8 passing (incl. new regression test), against real Postgres via `auth-server/local/docker-compose.yml`
- [x] `./mvnw compile` — clean
- [ ] Dynamo suite not re-run locally (LocalStack container blocked by an unrelated stale docker network on this machine); Dynamo implementation was not touched by this change

Closes #345